### PR TITLE
I3 configure tailwind with colour scheme and fonts

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,3 +1,29 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+  .heading-brandon {
+    font-family: theme("fontFamily.brandon");
+    letter-spacing: theme("letterSpacing.15");
+    font-weight: bold;
+  }
+
+  .heading-lato {
+    font-family: theme("fontFamily.lato");
+  }
+
+  .heading-futura {
+    font-family: theme("fontFamily.futura");
+    font-weight: bold;
+  }
+
+  .heading-jost {
+    font-family: theme("fontFamily.jost");
+  }
+
+  .body-brandon {
+    font-family: theme("fontFamily.brandon");
+    letter-spacing: theme("letterSpacing.12");
+  }
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,10 +1,20 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
-    css: ['~/assets/css/main.css'],
-    postcss: {
-        plugins: {
-            tailwindcss: {},
-            autoprefixer: {},
-        },
+  css: ["~/assets/css/main.css"],
+  postcss: {
+    plugins: {
+      tailwindcss: {},
+      autoprefixer: {},
     },
-})
+  },
+  app: {
+    head: {
+      link: [
+        {
+          rel: "stylesheet",
+          href: "https://fonts.googleapis.com/css?family=Lato&family=Jost",
+        },
+      ],
+    },
+  },
+});

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,7 +9,27 @@ module.exports = {
     "./app.vue",
   ],
   theme: {
+    colors: {
+      black: "#000000",
+      white: "#FFFFFF",
+      gold: "#FFD700",
+      "light-gold": "#FFEB87",
+      "light-grey": "#A8A8A8",
+      "mid-grey": "#8A8A8A",
+      "dark-grey": "#474747",
+      "light-organse-gold": "#FFBD4A",
+    },
+    fontFamily: {
+      brandon: ["brandon-grotesque", "sans-serif"],
+      lato: ["Lato", "sans-serif"],
+      futura: ["Futura", "sans-serif"],
+      jost: ["Jost", "sans-serif"],
+    },
+    letterSpacing: {
+      12: "0.12em",
+      15: "0.15em",
+    },
     extend: {},
   },
   plugins: [],
-}
+};


### PR DESCRIPTION
## Change Summary
**[Briefly summarise the changes that you made. Just high-level stuff]**
Created colors and fonts that can be used as classes.
To use fonts just add heading-'font' or body-brandon class
Colors can be used as normal classes based on tailwind documentation

### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [ / ] The pull request title has an issue number
- [ / ] The change works by "Smoke testing" or quick testing
- [ / ] The change has tests
- [ / ] The change has documentation

## Other Information
**[Is there anything in particular in the review that I should be aware of?]**

# Related issue

- Resolve #3