### PR TITLE
hotfixed adding <slot /> tag to default.vue

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,3 +1,4 @@
 <template>
   <NavBar />
+  <slot />
 </template>


### PR DESCRIPTION
## Change Summary
I failed to add a <slot /> to the default.vue file, which doesn't provide a space for other code to exist alongside the navbar, meaning things put on the index.vue page will not render. 

This fixes that, hopefully 

### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [NA ] The pull request title has an issue number
- [NA] The change works by "Smoke testing" or quick testing
- [NA] The change has tests
- [NA] The change has documentation

## Other Information
**[Is there anything in particular in the review that I should be aware of?]**