### PR TITLE
I71 Fixed `javascript-ci` Workflow Missing Errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,4 +9,9 @@ module.exports = {
   rules: {
     "vue/multi-word-component-names": 0,
   },
+  overrides: [
+    {
+      files: ["**.js", "**.cjs", "**.mjs", "**.vue"],
+    },
+  ],
 };

--- a/.github/workflows/javascript-ci.yml
+++ b/.github/workflows/javascript-ci.yml
@@ -26,4 +26,5 @@ jobs:
         uses: wearerequired/lint-action@66e2f9c9bf05b7aca19dbb59aebad95da5ddc537
         with:
           eslint: true
+          eslint_args: '--ignore-path .gitignore'
           neutral_check_on_warning: true

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
-    "lint": "eslint --ext .js,.ts,.vue --ignore-path .gitignore .",
-    "lint:fix": "eslint --ext .js,.ts,.vue --ignore-path .gitignore --fix .",
+    "lint": "eslint --ignore-path .gitignore .",
+    "lint:fix": "eslint --ignore-path .gitignore --fix .",
     "firebase": "yarn emu:stop & cd Firebase && firebase emulators:start",
     "emu:stop": "lsof -ti :9099 -ti :5001 -ti :8080 -ti :8085  -ti :9199 | xargs kill"
 

--- a/pages/institutions.vue
+++ b/pages/institutions.vue
@@ -41,8 +41,8 @@ const addInstitution = () => {};
       button-text="Add Institutions"
       button-color="bg-gold"
       type="button"
-      @click="addInstitution"
       class="m-5 ml-8"
+      @click="addInstitution"
     />
   </div>
 </template>


### PR DESCRIPTION
## Change Summary
- Moved valid file types in ESLint into `.eslintrc.js`, removing the need to specify `--ext`.
- Made `javascript-ci`s `lint` job honor `.gitignore`.
- Linted main

### Change Form
- [x] The pull request title has an issue number
- [x] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

# Related issue

- Resolve #71