### PR TITLE
i204-fix team number been repeated

### DIFF
--- a/stores/institutions.js
+++ b/stores/institutions.js
@@ -170,6 +170,7 @@ export const useInstitutionStore = defineStore("institution", {
       this.institutions = [];
     },
     async registerTeam(team) {
+      const userStore = useUserStore();
       // novice
       this.errorMessage = "";
       if (team.teams[0].levelPresent) {
@@ -228,7 +229,12 @@ export const useInstitutionStore = defineStore("institution", {
       if (!this.errorMessage) {
         this.errorMessage = "";
         const { $clientFirestore } = useNuxtApp();
-        let teamCounter = 1;
+        const query_ = query(
+          collection($clientFirestore, "teams"),
+          where("institutionId", "==", userStore.institution)
+        );
+        const snapshot = await getCountFromServer(query_);
+        let teamCounter = snapshot.data().count + 1;
         try {
           const batch = writeBatch($clientFirestore);
           team.teams.forEach((level) => {


### PR DESCRIPTION
## Change Summary
**[Briefly summarise the changes that you made. Just high-level stuff]**
- in teams, when a team is created the number will never start at 0 after each create batch

### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [x] The pull request title has an issue number
- [ ] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

## Other Information
**[Is there anything in particular in the review that I should be aware of?]**

# Related issue

- Resolve #204