### PR TITLE
I203 Fix Venue Preferences Being Sent When False

### DIFF
--- a/stores/institutions.js
+++ b/stores/institutions.js
@@ -250,7 +250,9 @@ export const useInstitutionStore = defineStore("institution", {
                   allocatedTue: i < overlap + tueOnly,
                   allocatedWed: i < overlap || i >= overlap + tueOnly,
                   hasVenuePreference: team.hasVenuePreference,
-                  venuePreference: team.venuePreference,
+                  venuePreference: team.hasVenuePreference
+                    ? team.venuePreference
+                    : null,
                   notes: team.notes,
                   division: null,
                 });


### PR DESCRIPTION
## Change Summary
- Made `venuePreference` null when `hasVenuePreference` is false in `registerTeam()`

### Change Form
- [x] The pull request title has an issue number
- [x] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation


# Related issue

- Resolve #203